### PR TITLE
Update main.py to make it function correctly

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,8 +8,7 @@ app = FastAPI(title="Upload Files by FastAPI")
 async def upload_files(files: List[UploadFile] = File(...)):
     file_list = []
     for single_file in files:
-        with open(single_file.filename, "wb") as buffer:
-            shutil.copy(single_file.filename, 'uploaded_files/')
-            os.remove(single_file.filename)
+        with open(f'uploaded_files/{single_file.filename}', "wb+") as file_object:
+            shutil.copyfileobj(single_file.file, file_object)    
         file_list.append(single_file.filename)
     return "The following files has been uploaded:" + str(file_list)


### PR DESCRIPTION
Currently, the code produces files with empty content (albeit the correct filenames). Instead of `shutil.copy`, `shutil.copyFileObj` was used to fix this.

Source: https://stackoverflow.com/questions/63580229/how-to-save-uploadfile-in-fastapi